### PR TITLE
Offer to install Firefox for Android rather than Firefox beta

### DIFF
--- a/src/org/mozilla/android/synthapk/C.java
+++ b/src/org/mozilla/android/synthapk/C.java
@@ -9,7 +9,7 @@ public final class C {
 
     public static final String TAG = "Gecko-synthapklib";
     public static final String WEBAPP_MIMETYPE = "application/webapp";
-    public static final String FENNEC_PACKAGE_NAME = "org.mozilla.firefox_beta";
+    public static final String FENNEC_PACKAGE_NAME = "org.mozilla.firefox";
 
     public static final String EXTRA_PACKAGE_NAME = "packageName";
     public static final String EXTRA_ICON_URI = "iconUri";


### PR DESCRIPTION
Currently users who do not have Firefox installed are offered to install a compatible run time, and in the play store they reach Firefox Beta. 
But apk factory apks work with Firefox for Android also. For someone who has never used Firefox on their phone, it is better to install the production version rather than beta.
